### PR TITLE
Initialize Next.js storefront with Tailwind and core pages

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+out
+.env
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# pet-dropshipping-store
+# Pet Dropshipping Store
+
+This project is a starter Next.js application for an online pet dropshipping store. It uses Tailwind CSS for styling and provides a basic set of pages:
+
+- **Home** – hero section and featured products.
+- **Products** – list of available products.
+- **Product Details** – detailed view with an Add to Cart button.
+- **Cart** – view items selected for purchase.
+- **Checkout** – placeholder page ready for payment integration.
+
+## Development
+
+```bash
+npm run dev
+```
+
+## Testing and Linting
+
+```bash
+npm test
+npm run lint
+```
+
+This setup is ready for future integration with services such as Stripe or PayPal.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  images: {
+    domains: ['placekitten.com', 'placebear.com'],
+  },
+}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "pet-dropshipping-store",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwindcss": "3.4.1",
+    "autoprefixer": "10.4.16",
+    "postcss": "8.4.31"
+  },
+  "devDependencies": {
+    "typescript": "5.4.5",
+    "@types/react": "18.2.37",
+    "@types/node": "20.11.30",
+    "@types/react-dom": "18.2.15",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.1.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useCart } from '@/context/CartContext';
+
+export default function CartPage() {
+  const { items, clearCart } = useCart();
+  const total = items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+
+  if (items.length === 0) {
+    return (
+      <div>
+        <h1 className="text-3xl font-bold mb-6">Your Cart</h1>
+        <p>Your cart is empty.</p>
+        <Link href="/products" className="text-blue-600 underline">Browse products</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h1 className="text-3xl font-bold mb-6">Your Cart</h1>
+      <ul className="space-y-4 mb-6">
+        {items.map((item) => (
+          <li key={item.id} className="flex items-center space-x-4">
+            <Image src={item.image} alt={item.title} width={80} height={80} className="rounded" />
+            <div className="flex-1">
+              <p className="font-medium">{item.title}</p>
+              <p className="text-sm text-gray-500">Qty: {item.quantity}</p>
+            </div>
+            <p>${(item.price * item.quantity).toFixed(2)}</p>
+          </li>
+        ))}
+      </ul>
+      <p className="text-xl font-semibold mb-4">Total: ${total.toFixed(2)}</p>
+      <div className="flex space-x-4">
+        <button onClick={clearCart} className="bg-gray-200 px-4 py-2 rounded">Clear Cart</button>
+        <Link href="/checkout" className="bg-blue-600 text-white px-4 py-2 rounded">Checkout</Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -1,0 +1,8 @@
+export default function CheckoutPage() {
+  return (
+    <div className="text-center">
+      <h1 className="text-3xl font-bold mb-4">Checkout</h1>
+      <p>Payment integration coming soon.</p>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-50 text-gray-900;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,33 @@
+import './globals.css';
+import { Inter } from 'next/font/google';
+import { ReactNode } from 'react';
+import Link from 'next/link';
+import { CartProvider } from '@/context/CartContext';
+
+const inter = Inter({ subsets: ['latin'] });
+
+export const metadata = {
+  title: 'Pet Dropshipping Store',
+  description: 'Online store for pet products',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>
+        <CartProvider>
+          <header className="bg-white shadow">
+            <div className="container mx-auto flex justify-between items-center p-4">
+              <Link href="/" className="text-xl font-bold">Pet Store</Link>
+              <nav className="space-x-4">
+                <Link href="/products">Products</Link>
+                <Link href="/cart">Cart</Link>
+              </nav>
+            </div>
+          </header>
+          <main className="container mx-auto p-4">{children}</main>
+        </CartProvider>
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { products } from '@/data/products';
+
+export default function Home() {
+  return (
+    <section className="text-center">
+      <div className="py-20 bg-gradient-to-r from-teal-400 to-blue-500 text-white rounded-lg">
+        <h1 className="text-4xl font-bold mb-4">Welcome to the Pet Store</h1>
+        <p className="mb-6">Find everything your pet needs.</p>
+        <Link href="/products" className="bg-white text-blue-600 px-4 py-2 rounded">Shop Now</Link>
+      </div>
+      <h2 className="text-2xl font-semibold mt-12 mb-4">Featured Products</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {products.slice(0, 3).map((product) => (
+          <Link key={product.id} href={`/products/${product.id}`} className="bg-white shadow rounded p-4 hover:shadow-lg transition block">
+            <Image src={product.image} alt={product.title} width={400} height={300} className="rounded mb-2 object-cover" />
+            <h3 className="text-lg font-medium">{product.title}</h3>
+            <p className="text-sm text-gray-500">${product.price.toFixed(2)}</p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import Image from 'next/image';
+import { products } from '@/data/products';
+import { useCart } from '@/context/CartContext';
+
+interface Props {
+  params: { id: string };
+}
+
+export default function ProductDetail({ params }: Props) {
+  const product = products.find((p) => p.id === params.id);
+  const { addToCart } = useCart();
+
+  if (!product) {
+    return <div>Product not found.</div>;
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <Image src={product.image} alt={product.title} width={600} height={400} className="rounded mb-4 object-cover" />
+      <h1 className="text-3xl font-bold mb-2">{product.title}</h1>
+      <p className="text-gray-700 mb-4">{product.description}</p>
+      <p className="text-xl font-semibold mb-6">${product.price.toFixed(2)}</p>
+      <button
+        onClick={() => addToCart(product)}
+        className="bg-blue-600 text-white px-4 py-2 rounded"
+      >
+        Add to Cart
+      </button>
+    </div>
+  );
+}

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { products } from '@/data/products';
+
+export default function ProductsPage() {
+  return (
+    <div>
+      <h1 className="text-3xl font-bold mb-6">Products</h1>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {products.map((product) => (
+          <Link key={product.id} href={`/products/${product.id}`} className="bg-white shadow rounded p-4 hover:shadow-lg transition block">
+            <Image src={product.image} alt={product.title} width={400} height={300} className="rounded mb-2 object-cover" />
+            <h3 className="text-lg font-medium">{product.title}</h3>
+            <p className="text-sm text-gray-500">${product.price.toFixed(2)}</p>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { createContext, useContext, useState, ReactNode } from 'react';
+import { Product } from '@/data/products';
+
+export interface CartItem extends Product {
+  quantity: number;
+}
+
+interface CartContextType {
+  items: CartItem[];
+  addToCart: (product: Product) => void;
+  clearCart: () => void;
+}
+
+const CartContext = createContext<CartContextType | undefined>(undefined);
+
+export const CartProvider = ({ children }: { children: ReactNode }) => {
+  const [items, setItems] = useState<CartItem[]>([]);
+
+  const addToCart = (product: Product) => {
+    setItems((prev) => {
+      const existing = prev.find((p) => p.id === product.id);
+      if (existing) {
+        return prev.map((p) =>
+          p.id === product.id ? { ...p, quantity: p.quantity + 1 } : p
+        );
+      }
+      return [...prev, { ...product, quantity: 1 }];
+    });
+  };
+
+  const clearCart = () => setItems([]);
+
+  return (
+    <CartContext.Provider value={{ items, addToCart, clearCart }}>
+      {children}
+    </CartContext.Provider>
+  );
+};
+
+export const useCart = () => {
+  const context = useContext(CartContext);
+  if (!context) {
+    throw new Error('useCart must be used within CartProvider');
+  }
+  return context;
+};

--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -1,0 +1,31 @@
+export interface Product {
+  id: string;
+  title: string;
+  description: string;
+  price: number;
+  image: string;
+}
+
+export const products: Product[] = [
+  {
+    id: '1',
+    title: 'Pet Collar',
+    description: 'Comfortable collar for your beloved pet.',
+    price: 9.99,
+    image: 'https://placekitten.com/400/300'
+  },
+  {
+    id: '2',
+    title: 'Dog Toy',
+    description: 'A fun squeaky toy to keep dogs entertained.',
+    price: 14.99,
+    image: 'https://placebear.com/400/300'
+  },
+  {
+    id: '3',
+    title: 'Cat Bed',
+    description: 'Soft and cozy bed for cats of all sizes.',
+    price: 29.99,
+    image: 'https://placekitten.com/401/300'
+  }
+];

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js 14 project with Tailwind CSS and TypeScript
- add home, products, product detail, cart, and checkout pages with basic UI and cart context
- document development, testing, and future payment integration in README

## Testing
- `npm test`
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a488065ec08326a348687638022040